### PR TITLE
:scissors: refactor: (system|ecosystem|project) -> platform

### DIFF
--- a/contributing/quickstart.md
+++ b/contributing/quickstart.md
@@ -12,7 +12,7 @@ https://goo.gl/forms/86y61YQx6bIAI8TF3
 
 ## Step 2: OpenMined Introduction
 
-This video covers the project as a whole including high level goals and the broad architecture strategies (the big moving parts!).
+This video covers the platform as a whole including high level goals and the broad architecture strategies (the big moving parts!).
 
 [![Watch the video](https://github.com/OpenMined/Docs/raw/master/img/OpenMinedIntro.png)](https://www.youtube.com/watch?v=sXFmKquiVnk)
 
@@ -20,7 +20,7 @@ This video covers the project as a whole including high level goals and the broa
 
 ## Step 3: Syft Installation + Homomorphic Encryption Demo
 
-Once you've got a general understanding of the project, you'll want to start with the basics, getting Homomorphic Encryption up and running within PySyft.
+Once you've got a general understanding of the platform, you'll want to start with the basics, getting Homomorphic Encryption up and running within PySyft.
 
 - [First, install PySyft](https://github.com/OpenMined/PySyft/)
 - [Second, test this notebook](https://github.com/OpenMined/PySyft/blob/master/notebooks/Syft%20-%20Paillier%20Homomorphic%20Encryption%20Example.ipynb)
@@ -42,7 +42,7 @@ In order to see our documentation and issues in all their full glory, you'll wan
 
 ## Step 7: Congratulations You're Ready!
 
-You now have the basics of the OpenMined ecosystem up and running and are ready to take on Beginner level projects (Issues). We've gone out of our way to make sure that there are a plethora of mini-projects (Issues) that are 100% entry level. The way to find one is to pick any project and click the "Issues" Tab at the top. This should take you to a place that looks like this.
+You now have the basics of the OpenMined ecosystem up and running and are ready to take on Beginner level projects (Issues). We've gone out of our way to make sure that there are a plethora of mini-projects (Issues) that are 100% entry level. The way to find one is to pick any repository and click the "Issues" Tab at the top. This should take you to a place that looks like this.
 
 ![Issues.png](https://github.com/OpenMined/Docs/raw/master/img/issues.png)
 

--- a/faq.md
+++ b/faq.md
@@ -2,7 +2,7 @@
 
 Please make sure to check the [Glossary and workflow](readme.md) before going through these questions.
 
-## Ecosystem
+## Platform
 
 > Q: How do people create their **own Mine**?
 
@@ -19,7 +19,7 @@ A: All data schemas will be publicly available and the before mentioned _adapter
 
 > Q: What is the current development state?
 
-A: Currently the [demo](https://github.com/OpenMined/PySonar/blob/master/notebooks/Sonar%20-%20Decentralized%20Model%20Training%20Simulation%20(local%20blockchain).ipynb) shows the overall workflow of OpenMined. In addition all the functional steps are implemented using available open source libraries or open code from our side. The next step for OpenMined will be a large(r) scale proof of concept. While running several mines in the system we will identify several issues regarding performance, usability and overall system design. Those will be tackled in a second development phase.
+A: Currently the [demo](https://github.com/OpenMined/PySonar/blob/master/notebooks/Sonar%20-%20Decentralized%20Model%20Training%20Simulation%20(local%20blockchain).ipynb) shows the overall workflow of OpenMined. In addition all the functional steps are implemented using available open source libraries or open code from our side. The next step for OpenMined will be a large(r) scale proof of concept. While running several mines on the platform we will identify several issues regarding performance, usability and overall platform design. Those will be tackled in a second development phase.
 
 ## Technology
 

--- a/feature_evolution.md
+++ b/feature_evolution.md
@@ -1,6 +1,6 @@
 # Feature Evolution Process
 
-> How does the OpenMined ecosystem develop new features? 🛣📈
+> How does the OpenMined platform develop new features? 🛣📈
 
 <!-- TOC depthFrom:2 -->
 
@@ -20,20 +20,20 @@
 
 Some words being used repeatedly in this document for quick reference. Most of them will be explained in detail later on.
 
-`❄️ Component`: An individual part of the OpenMined **system** (e.g. Mine, Sonar, Syft)
+`❄️ Component`: An individual part of the OpenMined **platform** (e.g. Mine, Sonar, Syft)
 
-`⛄️ System`: All of OpenMineds **components** working together
+`⛄️ Platform`: All of OpenMineds **components** working together
 
-`🛣 Roadmap`: Features of the whole **system** bundled into milestones
+`🛣 Roadmap`: Features of the whole **platform** bundled into milestones
 
 `💡 Featuremap`: A **component** specific list of features that are planned.
 
 `☑️ Issue`: A github issue which is the smallest description of a workpackage in a differential stlye (_add/remove .._), usually specific and belonging to a **component**
 
-`📝 Specification`: Describing an absolute state of either a **component** or the **system** (_component/system spec_). Every other milestone it might make sense to combine the differential **milestones** into a new system specification - or vice-versa.
+`📝 Specification`: Describing an absolute state of either a **component** or the **platform** (_component/platform spec_). Every other milestone it might make sense to combine the differential **milestones** into a new platform specification - or vice-versa.
 
 
-`📦 Milestone`: Baselined version of the whole **system** where all **components** have matching interfaces
+`📦 Milestone`: Baselined version of the whole **platform** where all **components** have matching interfaces
 
 `⚖️ acceptance criteria`: _aka Definition of Done (DoD)_, list of things that the change needs to fulfill to be considered a solution (comes with **issues** and **milestones**)
 
@@ -41,7 +41,7 @@ Some words being used repeatedly in this document for quick reference. Most of t
 
 `🎁 MVP`: Special **milestones** that are marketable to the outside
 
-`🚫 PoC, Project`: Just..don't use it please?
+`🚫 PoC, Platform`: Just..don't use it please?
 
 ## How work packages for components are defined
 
@@ -53,11 +53,11 @@ The key components in this step are described in detail below:
 
 ### Milestones
 
-> Baselined version of the whole **system** where all **components** have matching interfaces
+> Baselined version of the whole **platform** where all **components** have matching interfaces
 
 `Purpose`: Align contributors and provide
 
-`Where to find`: Defined in the system roadmap (_TODO@2017-08: link to actual roadmap_)
+`Where to find`: Defined in the platform roadmap (_TODO@2017-08: link to actual roadmap_)
 
 `Conventions`:
 * named after elements in the [periodic table](http://www.ptable.com/) in ascending order
@@ -73,7 +73,7 @@ The key components in this step are described in detail below:
 
 > One document to rule all milestones you must have 💍
 
-`Purpose`: Top Level document to get an understanding of current project status and future plans w/ **rough** timeplan
+`Purpose`: Top Level document to get an understanding of current platform status and future plans w/ **rough** timeplan
 
 `Where to find`: Markdown in the OpenMined/docs repositry. _TODO@2017-08: Link to trasks doc_
 

--- a/overview.md
+++ b/overview.md
@@ -1,4 +1,4 @@
-# Project Overview
+# Platform Overview
 
 Hi! Welcome to the Contributor Quickstart Guide! The purpose of this tutorial is to give you (all in one place!):
 
@@ -8,7 +8,7 @@ Hi! Welcome to the Contributor Quickstart Guide! The purpose of this tutorial is
 - [Workflow:](#workflow) how we work together as a team!
 - [Getting Started:](#start) the best places to start contributing
 
-assuming only that you have knowledge of basic Python programming one of the many fields of expertise this project needs. Let's get started!
+assuming only that you have knowledge of basic Python programming one of the many fields of expertise this platform needs. Let's get started!
 
 ## Vision
 

--- a/readme.md
+++ b/readme.md
@@ -2,15 +2,14 @@
 
 > all kinds of 📚 for OpenMined
 
-This top level project should provide helpful links to all available documentation.
+This repository should provide helpful links to all available documentation.
 
 <!-- TOC depthFrom:2 -->
 
 - [Overview](#overview)
+    - [Slides](#slides)
     - [Glossary](#glossary)
-    - [Overview](#overview)
-    - [Intro Slides](#slides)
-    - [Projects](#projects)
+    - [Components](#components)
     - [Repositories](#repositories)
     - [Workflow](#workflow)
     - [Incentives](#incentives)
@@ -45,7 +44,7 @@ This top level project should provide helpful links to all available documentati
 
 - **Bounty** - The amount of money a Data Scientist puts forth into training a Model which is later distributed amongst the mines involved in training the Model.
 
-### Projects
+### Components
 
 ![components](img/components-graphic.png)
 
@@ -66,7 +65,7 @@ PGP key generator, also responsible for delivering the trained and decrypted dat
 Blockchain contracts, holds all IPFS addresses for neural networks
 
 - **PySonar** _(Python)_  
-Python data science library for training models over the system
+Python data science library for training models over the platform
 
 - **Sonar UI** _(React.js)_  
 for creating campaigns and monitoring campaign progress/spend
@@ -90,7 +89,7 @@ Converting external data sources into OpenMined schemas
 Scripts/API that exposes public mine/sonar activity for analysis.
 
 ### Workflow
-The OpenMined system starts with a Data Scientist creating a request to Sonar in order to begin a mining campaign.  The Data Scientist defines some basic parameters:
+The OpenMined platform starts with a Data Scientist creating a request to Sonar in order to begin a mining campaign.  The Data Scientist defines some basic parameters:
 
 **Bounty**  
 The amount of money the Data Scientist is willing to spend in order the train their model


### PR DESCRIPTION
Align the way the OpenMined platform is referenced within the (onboarding) docs. Trying to _enforce_ `platform` for the whole thing (aka ecosytem, system, project) and `component` for an individual part. Exceptions: When talking about accessing issues for a `component` use `repository`